### PR TITLE
Revert "Add Elle's birthday"

### DIFF
--- a/config/precure.yml
+++ b/config/precure.yml
@@ -34,7 +34,3 @@ characters:
   # c.f. https://www.toei-anim.co.jp/tv/precure/character/cooking1.php
   - name:     ローズマリー
     birthday: "8/2"
-
-  # https://www.toei-anim.co.jp/tv/precure/character/chara5.php
-  - name:     エル
-    birthday: "3/12"


### PR DESCRIPTION
キュアマジェスティがrubicureに追加されてエルの誕生日を個別に追加する必要がなくなったので削除

c.f.

* https://github.com/sue445/rubicure/pull/289
* https://github.com/sue445/rubicure/blob/master/CHANGELOG.md#v323

Reverts sue445/precure-birthday-calendar#150